### PR TITLE
Custom Basic Authenticator for Username Only Based Authentication

### DIFF
--- a/custom-basic-authenticator-for-username-only-authentication/LICENSE
+++ b/custom-basic-authenticator-for-username-only-authentication/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/custom-basic-authenticator-for-username-only-authentication/README.md
+++ b/custom-basic-authenticator-for-username-only-authentication/README.md
@@ -1,0 +1,40 @@
+## Custom Basic Authenticator for Username only based Authentication.
+### Introduction / Use case.
+This is a custom basic authenticator allows the user to be authenticated only using the user name without prompting
+for the password. 
+
+### Applicable product versions.
+IS 5.7.0
+
+### How to use.
+* Build the sample jar file using the following command
+
+    ```mvn clean install```
+* Copy the **org.wso2.carbon.identity.application.authenticator.custombasicauth-6.0.6.jar** build, found in the **target/** directory to the **<IS_HOME>/repository/components/dropins/** directory.
+* Restart the server.
+* In your service provider configurations, instead of Basic authenticator select the "custom-basic"  You can change this authenticator friendly name according to your preference in your source code.
+
+### Testing the project.
+* We will testing by configuring the custom basic authenticator as the second authentication step.
+* We will also be configuring SMS OTP as the third authentication step. 
+* Enable the user name validation in the **Identifier-First** step by setting the **ValidateUsername** to **true**.
+* Apply the following configuration change to the **application-authentication.xml** file found in the **<IS_HOME>/repository/conf/identity/** directory. 
+    
+    ```
+    <AuthenticatorConfig name="IdentifierExecutor" enabled="true">
+       <Parameter name="ValidateUsername">true</Parameter>
+    </AuthenticatorConfig>
+    ```
+* Create a Service Provider with **Local & Outbound Authentication Configurations** -> **Advanced Configuration**.
+* Add 3 Authentication Steps
+    * Step 1 - identifier-first
+    * Step 2 - custom-basic (This is the newly deployed custom basic authenticator)
+    * Step 3 - SMS OTP (Need to create a Identity Provider for this Federated Authenticator) 
+* Follow the documentation to [1] configure SMS-OTP. 
+
+* Custom Basic Authenticator with Username only Authentication is tested aganinst the following scenarios.
+    * User created under super-tenant in the Primary user store (**admin@carbon.super/admin**)
+    * User created under a tenant domain in the Primary user store (**testUser@test.com**)
+    * User created under a tenant domain in the Secondary user store (**Secondary/testUser1@test.com**)
+ 
+ [1]https://docs.wso2.com/display/IS570/Configuring+SMS+OTP

--- a/custom-basic-authenticator-for-username-only-authentication/pom.xml
+++ b/custom-basic-authenticator-for-username-only-authentication/pom.xml
@@ -1,0 +1,531 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>org.wso2.carbon.identity.application.auth.basic</groupId>
+    <modelVersion>4.0.0</modelVersion>
+    <version>6.0.6</version>
+    <artifactId>org.wso2.carbon.identity.application.authenticator.custombasicauth</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Custom BasicAuth Identity Application Authenticator</name>
+    <description>
+
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+            <version>${eclipse.osgi.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <version>${apache.felix.scr.ds.annotations.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.logging</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core.services</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+
+        <!-- Identity Framework dependencies -->
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.base</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.event.stream.core</artifactId>
+            <version>${carbon.analytics-common.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons-logging.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons-lang.wso2.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>${nimbusds.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${json-smart.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.googlecode.json-simple.wso2</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>${json-simple.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>${jacoco.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+            <version>${testng.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <scope>test</scope>
+            <version>${org.powermock.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+            <version>${org.powermock.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${org.slf4j.verison}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${org.slf4j.verison}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+            <version>${org.wso2.carbon.identity.testutil.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+
+        <pluginRepository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <scm>
+        <connection>scm:svn:http://127.0.0.1/dummy</connection>
+        <developerConnection>scm:svn:https://127.0.0.1/dummy</developerConnection>
+        <tag>HEAD</tag>
+        <url>http://127.0.0.1/dummy</url>
+    </scm>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!--<plugin>-->
+                    <!--<groupId>org.apache.felix</groupId>-->
+                    <!--<artifactId>maven-scr-plugin</artifactId>-->
+                    <!--<version>1.7.2</version>-->
+                    <!--<executions>-->
+                        <!--<execution>-->
+                            <!--<id>generate-scr-scrdescriptor</id>-->
+                            <!--<goals>-->
+                                <!--<goal>scr</goal>-->
+                            <!--</goals>-->
+                        <!--</execution>-->
+                    <!--</executions>-->
+                <!--</plugin>-->
+                <!--<plugin>-->
+                    <!--<groupId>org.apache.felix</groupId>-->
+                    <!--<artifactId>maven-bundle-plugin</artifactId>-->
+                    <!--<version>2.4.0</version>-->
+                    <!--<extensions>true</extensions>-->
+                    <!--<configuration>-->
+                        <!--<obrRepository>NONE</obrRepository>-->
+                        <!--<instructions>-->
+                            <!--<SCM-Revision>${buildNumber}</SCM-Revision>-->
+                        <!--</instructions>-->
+                    <!--</configuration>-->
+                <!--</plugin>-->
+                <!--<plugin>-->
+                    <!--<groupId>org.codehaus.mojo</groupId>-->
+                    <!--<artifactId>buildnumber-maven-plugin</artifactId>-->
+                    <!--<version>${maven.buildnumber.plugin.version}</version>-->
+                    <!--<executions>-->
+                        <!--<execution>-->
+                            <!--<phase>validate</phase>-->
+                            <!--<goals>-->
+                                <!--<goal>create</goal>-->
+                            <!--</goals>-->
+                        <!--</execution>-->
+                    <!--</executions>-->
+                    <!--<configuration>-->
+                        <!--<doCheck>false</doCheck>-->
+                        <!--<doUpdate>false</doUpdate>-->
+                        <!--<revisionOnScmFailure>no.scm.config.in.pom</revisionOnScmFailure>-->
+                    <!--</configuration>-->
+                <!--</plugin>-->
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>1.7.2</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <obrRepository>NONE</obrRepository>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.application.authenticator.custombasicauth.internal
+                        </Private-Package>
+                        <Import-Package>
+                            <!--javax.servlet.http; version="${imp.pkg.version.javax.servlet}",-->
+
+                            <!--org.apache.commons.logging; version="${commons-logging.osgi.version.range}",-->
+                            <!--org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",-->
+
+                            <!--org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",-->
+                            <!--org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",-->
+
+                            <!--org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.framework.imp.pkg.version.range}",-->
+                            <!--org.wso2.carbon.identity.application.common.*;version="${carbon.identity.framework.imp.pkg.version.range}",-->
+                            <!--org.wso2.carbon.identity.base;version="${carbon.identity.framework.imp.pkg.version.range}",-->
+                            <!--org.wso2.carbon.identity.core.model;version="${carbon.identity.framework.imp.pkg.version.range}",-->
+                            <!--org.wso2.carbon.identity.core.util;version="${carbon.identity.framework.imp.pkg.version.range}",-->
+
+                            <!--org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",-->
+
+                            <!--org.wso2.carbon.user.core; version="${carbon.kernel.imp.pkg.version.range}",-->
+                            <!--org.wso2.carbon.user.core.service; version="${carbon.kernel.imp.pkg.version.range}",-->
+                            <!--org.wso2.carbon.user.core.util; version="${carbon.kernel.imp.pkg.version.range}",-->
+                            <!--org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.imp.pkg.version.range}"-->
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.application.authenticator.custombasicauth.internal,
+                            org.wso2.carbon.identity.application.authenticator.custombasicauth.*;version="${identity.application.auth.basicauth.exp.pkg.version}"
+                        </Export-Package>
+                        <!--<SCM-Revision>${buildNumber}</SCM-Revision>-->
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <!--This points to the location of CustomBasicAuthenticator's TestNG file-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.1</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>${maven.buildnumber.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <doCheck>false</doCheck>
+                    <doUpdate>false</doUpdate>
+                    <revisionOnScmFailure>no.scm.config.in.pom</revisionOnScmFailure>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.9</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <!-- Identity Local Auth CustomBasicAuth version -->
+        <identity.application.auth.basicauth.exp.pkg.version>${project.version}
+        </identity.application.auth.basicauth.exp.pkg.version>
+        <identity.application.auth.basicauth.imp.pkg.version.range>[5.0.0, 7.0.0)
+        </identity.application.auth.basicauth.imp.pkg.version.range>
+
+        <!-- Carbon Kernel version -->
+        <carbon.kernel.version>4.4.11</carbon.kernel.version>
+        <carbon.kernel.imp.pkg.version.range>[4.4.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
+        <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
+        <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
+
+        <!-- Carbon Identity Framework version -->
+        <carbon.identity.framework.version>5.12.181</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.7.0, 6.0.0)
+        </carbon.identity.framework.imp.pkg.version.range>
+
+        <!-- Carbon Analytics version -->
+        <carbon.analytics-common.version>5.0.11</carbon.analytics-common.version>
+        <carbon.analytics-common.imp.pkg.version.range>[5.0.0,6.0.0)</carbon.analytics-common.imp.pkg.version.range>
+
+        <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
+        <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
+        <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
+
+        <!-- Commons version -->
+        <commons-logging.version>1.2</commons-logging.version>
+        <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
+        <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
+
+        <nimbusds.version>5.8.0.wso2v1</nimbusds.version>
+        <nimbusds.imp.pkg.version.range>[5.8.0,6.0.0)</nimbusds.imp.pkg.version.range>
+        <json-simple.version>1.1.wso2v1</json-simple.version>
+        <json-smart.version>1.3</json-smart.version>
+        <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
+        <eclipse.osgi.version>3.5.100.v20160504-1419</eclipse.osgi.version>
+
+        <!-- Maven plugin version -->
+        <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
+        <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
+        <maven.source.plugin.version>1.22.0</maven.source.plugin.version>
+
+        <testng.version>6.9.10</testng.version>
+        <jacoco.version>0.7.9</jacoco.version>
+        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <org.slf4j.verison>1.6.1</org.slf4j.verison>
+        <org.powermock.version>1.6.6</org.powermock.version>
+        <org.wso2.carbon.identity.testutil.version>5.10.0</org.wso2.carbon.identity.testutil.version>
+    </properties>
+</project>

--- a/custom-basic-authenticator-for-username-only-authentication/src/main/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/CustomBasicAuthenticator.java
+++ b/custom-basic-authenticator-for-username-only-authentication/src/main/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/CustomBasicAuthenticator.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.custombasicauth;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.*;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authenticator.custombasicauth.internal.CustomBasicAuthenticatorServiceComponent;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Username Only based Custom Basic Authenticator
+ */
+public class CustomBasicAuthenticator extends AbstractApplicationAuthenticator
+        implements LocalApplicationAuthenticator {
+
+    private static final long serialVersionUID = 1819664539416029785L;
+    private static final Log log = LogFactory.getLog(CustomBasicAuthenticator.class);
+    private static String RE_CAPTCHA_USER_DOMAIN = "user-domain-recaptcha";
+
+    @Override
+    public boolean canHandle(HttpServletRequest request) {
+        String userName = request.getParameter(CustomBasicAuthenticatorConstants.USER_NAME);
+        return userName != null;
+    }
+
+    @Override
+    public AuthenticatorFlowStatus process(HttpServletRequest request,
+                                           HttpServletResponse response, AuthenticationContext context)
+            throws AuthenticationFailedException, LogoutFailedException {
+
+        if (context.isLogoutRequest()) {
+            return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
+        } else {
+            // if an authentication flow
+            if (!context.isLogoutRequest()) {
+                if (!canHandle(request)
+                        || Boolean.TRUE.equals(request.getAttribute(FrameworkConstants.REQ_ATTR_HANDLED))) {
+                    if (getName().equals(context.getProperty(FrameworkConstants.LAST_FAILED_AUTHENTICATOR))) {
+                        context.setRetrying(true);
+                    }
+                    context.setCurrentAuthenticator(getName());
+                    context.setRetrying(false);
+                    try {
+                        processAuthenticationResponse(request, response, context);
+                        if (this instanceof LocalApplicationAuthenticator) {
+                            if (!context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
+                                String userDomain = context.getSubject().getTenantDomain();
+                                String tenantDomain = context.getTenantDomain();
+                                if (!StringUtils.equals(userDomain, tenantDomain)) {
+                                    context.setProperty("UserTenantDomainMismatch", true);
+                                    throw new AuthenticationFailedException("Service Provider tenant domain must be " +
+                                            "equal to user tenant domain for non-SaaS applications", context.getSubject());
+                                }
+                            }
+                        }
+                        request.setAttribute(FrameworkConstants.REQ_ATTR_HANDLED, true);
+                        context.setProperty(FrameworkConstants.LAST_FAILED_AUTHENTICATOR, null);
+                        return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
+                    } catch (AuthenticationFailedException e) {
+                        request.setAttribute(FrameworkConstants.REQ_ATTR_HANDLED, true);
+                        context.setProperty(FrameworkConstants.LAST_FAILED_AUTHENTICATOR, getName());
+                        return AuthenticatorFlowStatus.INCOMPLETE;
+
+                    }
+                }
+                return AuthenticatorFlowStatus.INCOMPLETE;
+                // if a logout flow
+            } else {
+                try {
+                    if (!canHandle(request)) {
+                        context.setCurrentAuthenticator(getName());
+                        initiateLogoutRequest(request, response, context);
+                        return AuthenticatorFlowStatus.INCOMPLETE;
+                    } else {
+                        processLogoutResponse(request, response, context);
+                        return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
+                    }
+                } catch (UnsupportedOperationException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Ignoring UnsupportedOperationException.", e);
+                    }
+                    return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void processAuthenticationResponse(HttpServletRequest request,
+                                                 HttpServletResponse response, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        String username = request.getParameter(CustomBasicAuthenticatorConstants.USER_NAME);
+
+        Map<String, Object> authProperties = context.getProperties();
+        if (authProperties == null) {
+            authProperties = new HashMap<>();
+            context.setProperties(authProperties);
+        }
+
+        Map<String, String> runtimeParams = getRuntimeParams(context);
+        if (runtimeParams != null) {
+            String usernameFromContext = runtimeParams.get(FrameworkConstants.JSAttributes.JS_OPTIONS_USERNAME);
+            if (usernameFromContext != null && !usernameFromContext.equals(username)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Username set for identifier first login: " + usernameFromContext + " and username " +
+                            "submitted from login page" + username + " does not match.");
+                }
+                throw new InvalidCredentialsException("Credential mismatch.");
+            }
+        }
+
+        boolean isAuthenticated;
+        UserStoreManager userStoreManager;
+        // Reset RE_CAPTCHA_USER_DOMAIN thread local variable before the authentication
+        IdentityUtil.threadLocalProperties.get().remove(RE_CAPTCHA_USER_DOMAIN);
+        // Check the authentication
+        try {
+            int tenantId = IdentityTenantUtil.getTenantIdOfUser(username);
+            UserRealm userRealm = CustomBasicAuthenticatorServiceComponent.getRealmService().getTenantUserRealm(tenantId);
+            if (userRealm != null) {
+                userStoreManager = (UserStoreManager) userRealm.getUserStoreManager();
+                isAuthenticated = userStoreManager.isExistingUser(MultitenantUtils.getTenantAwareUsername(username));
+            } else {
+                throw new AuthenticationFailedException("Cannot find the user realm for the given tenant: " +
+                        tenantId, User.getUserFromUserName(username));
+            }
+        } catch (IdentityRuntimeException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("CustomBasicAuthentication failed while trying to get the tenant ID of the user " + username, e);
+            }
+            throw new AuthenticationFailedException(e.getMessage(), User.getUserFromUserName(username), e);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("CustomBasicAuthentication failed while trying to authenticate", e);
+            }
+            throw new AuthenticationFailedException(e.getMessage(), User.getUserFromUserName(username), e);
+        }
+
+        if (!isAuthenticated) {
+            if (log.isDebugEnabled()) {
+                log.debug("User authentication failed due to invalid credentials");
+            }
+            if (IdentityUtil.threadLocalProperties.get().get(RE_CAPTCHA_USER_DOMAIN) != null) {
+                username = IdentityUtil.addDomainToName(
+                        username, IdentityUtil.threadLocalProperties.get().get(RE_CAPTCHA_USER_DOMAIN).toString());
+            }
+            IdentityUtil.threadLocalProperties.get().remove(RE_CAPTCHA_USER_DOMAIN);
+            throw new InvalidCredentialsException("User authentication failed due to invalid credentials",
+                    User.getUserFromUserName(username));
+        }
+
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
+
+        //TODO: user tenant domain has to be an attribute in the AuthenticationContext
+        authProperties.put("user-tenant-domain", tenantDomain);
+
+        username = FrameworkUtils.prependUserStoreDomainToName(username);
+
+        if (getAuthenticatorConfig().getParameterMap() != null) {
+            String userNameUri = getAuthenticatorConfig().getParameterMap().get("UserNameAttributeClaimUri");
+            if (StringUtils.isNotBlank(userNameUri)) {
+                boolean multipleAttributeEnable;
+                String domain = UserCoreUtil.getDomainFromThreadLocal();
+                if (StringUtils.isNotBlank(domain)) {
+                    multipleAttributeEnable = Boolean.parseBoolean(userStoreManager.getSecondaryUserStoreManager(domain)
+                            .getRealmConfiguration().getUserStoreProperty("MultipleAttributeEnable"));
+                } else {
+                    multipleAttributeEnable = Boolean.parseBoolean(userStoreManager.
+                            getRealmConfiguration().getUserStoreProperty("MultipleAttributeEnable"));
+                }
+                if (multipleAttributeEnable) {
+                    try {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Searching for UserNameAttribute value for user " + username +
+                                    " for claim uri : " + userNameUri);
+                        }
+                        String usernameValue = userStoreManager.
+                                getUserClaimValue(MultitenantUtils.getTenantAwareUsername(username), userNameUri, null);
+                        if (StringUtils.isNotBlank(usernameValue)) {
+                            tenantDomain = MultitenantUtils.getTenantDomain(username);
+                            usernameValue = FrameworkUtils.prependUserStoreDomainToName(usernameValue);
+                            username = usernameValue + "@" + tenantDomain;
+                            if (log.isDebugEnabled()) {
+                                log.debug("UserNameAttribute is found for user. Value is :  " + username);
+                            }
+                        }
+                    } catch (UserStoreException e) {
+                        //ignore  but log in debug
+                        if (log.isDebugEnabled()) {
+                            log.debug("Error while retrieving UserNameAttribute for user : " + username, e);
+                        }
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("MultipleAttribute is not enabled for user store domain : " + domain + " " +
+                                "Therefore UserNameAttribute is not retrieved");
+                    }
+                }
+            }
+        }
+
+        context.setSubject(AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username));
+    }
+
+    @Override
+    protected boolean retryAuthenticationEnabled() {
+        return true;
+    }
+
+    @Override
+    public String getContextIdentifier(HttpServletRequest request) {
+        return request.getParameter("sessionDataKey");
+    }
+
+    @Override
+    public String getFriendlyName() {
+        return CustomBasicAuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
+    }
+
+    @Override
+    public String getName() {
+        return CustomBasicAuthenticatorConstants.AUTHENTICATOR_NAME;
+    }
+}

--- a/custom-basic-authenticator-for-username-only-authentication/src/main/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/CustomBasicAuthenticatorConstants.java
+++ b/custom-basic-authenticator-for-username-only-authentication/src/main/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/CustomBasicAuthenticatorConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.custombasicauth;
+
+/**
+ * Constants used by the CustomBasicAuthenticator
+ */
+public class CustomBasicAuthenticatorConstants {
+
+    public static final String AUTHENTICATOR_NAME = "CustomBasicAuthenticator";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "custom-basic";
+    public static final String USER_NAME = "username";
+
+    private CustomBasicAuthenticatorConstants() {
+    }
+}

--- a/custom-basic-authenticator-for-username-only-authentication/src/main/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/internal/CustomBasicAuthenticatorServiceComponent.java
+++ b/custom-basic-authenticator-for-username-only-authentication/src/main/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/internal/CustomBasicAuthenticatorServiceComponent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.custombasicauth.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authenticator.custombasicauth.CustomBasicAuthenticator;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * @scr.component name="identity.application.authenticator.custom.basicauth.component" immediate="true"
+ * @scr.reference name="realm.service"
+ * interface="org.wso2.carbon.user.core.service.RealmService"cardinality="1..1"
+ * policy="dynamic" bind="setRealmService" unbind="unsetRealmService"
+ */
+public class CustomBasicAuthenticatorServiceComponent {
+
+    private static Log log = LogFactory.getLog(CustomBasicAuthenticatorServiceComponent.class);
+
+    private static RealmService realmService;
+
+    public static RealmService getRealmService() {
+        return realmService;
+    }
+
+    protected void setRealmService(RealmService realmService) {
+        log.debug("Setting the Realm Service");
+        CustomBasicAuthenticatorServiceComponent.realmService = realmService;
+    }
+
+    protected void activate(ComponentContext ctxt) {
+        try {
+            CustomBasicAuthenticator basicAuth = new CustomBasicAuthenticator();
+            ctxt.getBundleContext().registerService(ApplicationAuthenticator.class.getName(), basicAuth, null);
+            if (log.isDebugEnabled()) {
+                log.debug("CustomBasicAuthenticator bundle is activated");
+            }
+        } catch (Throwable e) {
+            log.error("SAMLSSO Authenticator bundle activation Failed", e);
+        }
+    }
+
+    protected void deactivate(ComponentContext ctxt) {
+        if (log.isDebugEnabled()) {
+            log.debug("CustomBasicAuthenticator bundle is deactivated");
+        }
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+        if (log.isDebugEnabled()) {
+            log.debug("UnSetting the Realm Service");
+        }
+        CustomBasicAuthenticatorServiceComponent.realmService = null;
+    }
+}

--- a/custom-basic-authenticator-for-username-only-authentication/src/test/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/CustomBasicAuthenticatorTestCase.java
+++ b/custom-basic-authenticator-for-username-only-authentication/src/test/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/CustomBasicAuthenticatorTestCase.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.custombasicauth;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authenticator.custombasicauth.internal.CustomBasicAuthenticatorServiceComponent;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit test cases for the Custom Basic Authenticator.
+ */
+@PrepareForTest({IdentityTenantUtil.class, CustomBasicAuthenticatorServiceComponent.class, User
+        .class, MultitenantUtils.class, FrameworkUtils.class, FileBasedConfigurationBuilder.class,
+        IdentityUtil.class, UserCoreUtil.class})
+public class CustomBasicAuthenticatorTestCase extends PowerMockIdentityBaseTest {
+
+    private HttpServletRequest mockRequest;
+    private HttpServletResponse mockResponse;
+    private AuthenticationContext mockAuthnCtxt;
+    private RealmService mockRealmService;
+    private UserRealm mockRealm;
+    private UserStoreManager mockUserStoreManager;
+    private FileBasedConfigurationBuilder mockFileBasedConfigurationBuilder;
+    private User mockUser;
+
+    private AuthenticatedUser authenticatedUser;
+
+    private String dummyUserName = "dummyUserName";
+    private String dummyPassword = "dummyPassword";
+    private int dummyTenantId = -1234;
+    private String dummyVal = "dummyVal";
+    private String dummyDomainName = "dummyDomain";
+
+    private CustomBasicAuthenticator customBasicAuthenticator;
+
+    @BeforeTest
+    public void setup() {
+
+        customBasicAuthenticator = new CustomBasicAuthenticator();
+    }
+
+    @DataProvider(name = "UsernameAndPasswordProvider")
+    public Object[][] getWrongUsername() {
+
+        return new String[][]{
+                {"admin", "true"},
+                {null, "false"},
+                {"", "true"}
+        };
+    }
+
+    @Test(dataProvider = "UsernameAndPasswordProvider")
+    public void canHandleTestCase(String userName, String expected) {
+
+        mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getParameter(CustomBasicAuthenticatorConstants.USER_NAME)).thenReturn(userName);
+        assertEquals(Boolean.valueOf(expected).booleanValue(), customBasicAuthenticator.canHandle(mockRequest),
+                "Invalid can handle response for the request.");
+    }
+
+    @Test
+    public void processSuccessTestCase() throws Exception {
+
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+        mockAuthnCtxt = mock(AuthenticationContext.class);
+        when(mockAuthnCtxt.isLogoutRequest()).thenReturn(true);
+        assertEquals(customBasicAuthenticator.process(mockRequest, mockResponse, mockAuthnCtxt),
+                AuthenticatorFlowStatus.SUCCESS_COMPLETED);
+    }
+
+    @Test
+    public void processIncompleteTestCase() throws IOException, AuthenticationFailedException, LogoutFailedException {
+
+        when(mockAuthnCtxt.isLogoutRequest()).thenReturn(false);
+        assertEquals(customBasicAuthenticator.process(mockRequest, mockResponse, mockAuthnCtxt),
+                AuthenticatorFlowStatus.INCOMPLETE);
+    }
+
+    @Test
+    public void getFriendlyNameTestCase() {
+
+        assertEquals(customBasicAuthenticator.getFriendlyName(), CustomBasicAuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME);
+    }
+
+    @Test
+    public void getNameTestCase() {
+
+        assertEquals(customBasicAuthenticator.getName(), CustomBasicAuthenticatorConstants.AUTHENTICATOR_NAME);
+    }
+
+    @Test
+    public void retryAuthenticationEnabledTestCase() {
+
+        assertTrue(customBasicAuthenticator.retryAuthenticationEnabled());
+    }
+
+    @Test
+    public void getContextIdentifierTestCase() {
+
+        mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getParameter("sessionDataKey")).thenReturn(dummyVal);
+        assertEquals(customBasicAuthenticator.getContextIdentifier(mockRequest), dummyVal);
+    }
+
+    @DataProvider(name = "realmProvider")
+    public Object[][] getRealm() {
+
+        mockRealm = mock(UserRealm.class);
+        mockUserStoreManager = mock(UserStoreManager.class);
+
+        return new Object[][]{
+                {null, "Cannot find the user realm for the given tenant: " + dummyTenantId, null},
+                {mockRealm, "User authentication failed due to invalid credentials", dummyVal},
+                {mockRealm, "User authentication failed due to invalid credentials", null},
+        };
+    }
+
+    @Test(dataProvider = "realmProvider")
+    public void processAuthenticationResponseTestCaseForException(Object realm, Object expected, Object
+            recapchaUserDomain) throws Exception {
+
+        mockAuthnCtxt = mock(AuthenticationContext.class);
+        when(mockAuthnCtxt.getProperties()).thenReturn(new HashMap<String, Object>());
+
+        mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getParameter(CustomBasicAuthenticatorConstants.USER_NAME)).thenReturn(dummyUserName);
+
+        mockResponse = mock(HttpServletResponse.class);
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantIdOfUser(dummyUserName)).thenReturn(dummyTenantId);
+
+        mockStatic(CustomBasicAuthenticatorServiceComponent.class);
+        mockRealmService = mock(RealmService.class);
+        when(CustomBasicAuthenticatorServiceComponent.getRealmService()).thenReturn(mockRealmService);
+        when(CustomBasicAuthenticatorServiceComponent.getRealmService().getTenantUserRealm(dummyTenantId)).thenReturn((UserRealm) realm);
+        when(mockRealm.getUserStoreManager()).thenReturn(mockUserStoreManager);
+
+        mockStatic(MultitenantUtils.class);
+        when(MultitenantUtils.getTenantAwareUsername(dummyUserName)).thenReturn(dummyPassword);
+        when(mockUserStoreManager.isExistingUser(
+                MultitenantUtils.getTenantAwareUsername(dummyUserName))).thenReturn(false);
+
+        mockStatic(IdentityUtil.class);
+        Map<String, Object> mockedThreadLocalMap = new HashMap<>();
+        mockedThreadLocalMap.put("user-domain-recaptcha", recapchaUserDomain);
+        IdentityUtil.threadLocalProperties.set(mockedThreadLocalMap);
+
+        mockUser = mock(User.class);
+        when(mockUser.getUserName()).thenReturn(dummyUserName);
+        mockStatic(User.class);
+        when(User.getUserFromUserName(anyString())).thenReturn(mockUser);
+        try {
+            customBasicAuthenticator.processAuthenticationResponse(mockRequest, mockResponse, mockAuthnCtxt);
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(), expected);
+        }
+    }
+
+    @DataProvider(name = "multipleAttributeprovider")
+    public Object[][] getMultipleAttributeProvider() {
+
+        String dummyUserNameValue = "dummyusernameValue";
+        return new String[][]{
+                {null, dummyUserName, null, "true", "false"},
+                {null, dummyUserName, "", "true", "false"},
+                {null, dummyUserName, dummyUserNameValue, "true", "true"},
+                {null, dummyUserName, dummyUserNameValue, "true", "false"},
+                {null, dummyUserName, null, "false", "true"},
+                {null, dummyUserName, null, "false", "false"},
+                {"", dummyUserName, null, "false", "false"},
+                {dummyDomainName, dummyUserName, null, "false", "false"},
+                {null, "", null, "false", "false"},
+                {null, null, null, "false", "false"}
+        };
+    }
+
+    @Test(dataProvider = "multipleAttributeprovider")
+    public void processAuthenticationResponseTestcaseWithMultiAttribute(String domainName, String userNameUri,
+            String userNameValue, String multipleAttributeEnable, String debugEnabled)
+            throws UserStoreException, NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+            AuthenticationFailedException, NoSuchFieldException {
+
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put("UserNameAttributeClaimUri", userNameUri);
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig(dummyUserName, true, parameterMap);
+
+        processAuthenticationResponseStartUp();
+
+        mockStatic(FileBasedConfigurationBuilder.class);
+        mockFileBasedConfigurationBuilder = mock(FileBasedConfigurationBuilder.class);
+        when(FileBasedConfigurationBuilder.getInstance()).thenReturn(mockFileBasedConfigurationBuilder);
+        when(FileBasedConfigurationBuilder.getInstance().getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
+
+        mockStatic(UserCoreUtil.class);
+        when(UserCoreUtil.getDomainFromThreadLocal()).thenReturn(domainName);
+
+        RealmConfiguration mockRealmConfiguration = mock(RealmConfiguration.class);
+
+        if (StringUtils.isNotBlank(domainName)) {
+            when(mockUserStoreManager.getSecondaryUserStoreManager(dummyDomainName)).thenReturn(mockUserStoreManager);
+        }
+
+        when(mockUserStoreManager
+                .getRealmConfiguration()).thenReturn(mockRealmConfiguration);
+
+        when(mockRealmConfiguration.getUserStoreProperty("MultipleAttributeEnable"))
+                .thenReturn(multipleAttributeEnable);
+
+        when(mockUserStoreManager.
+                getUserClaimValue(MultitenantUtils.getTenantAwareUsername(dummyUserName), dummyUserName, null))
+                .thenReturn(userNameValue);
+
+        when(MultitenantUtils.getTenantDomain(dummyUserName)).thenReturn("dummyTenantDomain");
+        when(FrameworkUtils.prependUserStoreDomainToName(userNameValue)).thenReturn(dummyDomainName +
+                CarbonConstants.DOMAIN_SEPARATOR + userNameValue);
+
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn(dummyDomainName);
+
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+
+                authenticatedUser = (AuthenticatedUser) invocation.getArguments()[0];
+                return null;
+            }
+        }).when(mockAuthnCtxt).setSubject(any(AuthenticatedUser.class));
+
+        customBasicAuthenticator.processAuthenticationResponse(mockRequest, mockResponse, mockAuthnCtxt);
+
+        if (StringUtils.isNotBlank(userNameValue)) {
+            assertEquals(authenticatedUser.getAuthenticatedSubjectIdentifier(), dummyDomainName +
+                    CarbonConstants.DOMAIN_SEPARATOR + userNameValue + "@" + "dummyTenantDomain");
+        } else {
+            assertEquals(authenticatedUser.getAuthenticatedSubjectIdentifier(), dummyUserName);
+        }
+
+    }
+
+    private void processAuthenticationResponseStartUp() throws UserStoreException {
+
+        mockAuthnCtxt = mock(AuthenticationContext.class);
+        when(mockAuthnCtxt.getProperties()).thenReturn(null);
+
+        mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getParameter(CustomBasicAuthenticatorConstants.USER_NAME)).thenReturn(dummyUserName);
+
+        mockResponse = mock(HttpServletResponse.class);
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantIdOfUser(dummyUserName)).thenReturn(dummyTenantId);
+
+        mockStatic(CustomBasicAuthenticatorServiceComponent.class);
+        mockRealmService = mock(RealmService.class);
+        when(CustomBasicAuthenticatorServiceComponent.getRealmService()).thenReturn(mockRealmService);
+        mockRealm = mock(UserRealm.class);
+        mockUserStoreManager = mock(UserStoreManager.class);
+        when(CustomBasicAuthenticatorServiceComponent.getRealmService().getTenantUserRealm(dummyTenantId)).thenReturn(mockRealm);
+        when(mockRealm.getUserStoreManager()).thenReturn(mockUserStoreManager);
+
+        mockStatic(MultitenantUtils.class);
+        when(MultitenantUtils.getTenantAwareUsername(dummyUserName)).thenReturn(dummyUserName);
+        when(mockUserStoreManager.isExistingUser(
+                MultitenantUtils.getTenantAwareUsername(dummyUserName))).thenReturn(true);
+
+        mockUser = mock(User.class);
+        when(mockUser.getUserName()).thenReturn(dummyUserName);
+        mockStatic(User.class);
+        when(User.getUserFromUserName(anyString())).thenReturn(mockUser);
+
+        mockStatic(FrameworkUtils.class);
+        when(MultitenantUtils.getTenantDomain(anyString())).thenReturn("carbon.super");
+        when(FrameworkUtils.prependUserStoreDomainToName(anyString())).thenReturn(dummyUserName);
+    }
+
+    @Test
+    public void processAuthenticationResponseTestcaseWithuserStoreException() throws IOException,
+            UserStoreException, NoSuchFieldException, IllegalAccessException {
+
+        mockAuthnCtxt = mock(AuthenticationContext.class);
+        when(mockAuthnCtxt.getProperties()).thenReturn(null);
+
+        mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getParameter(CustomBasicAuthenticatorConstants.USER_NAME)).thenReturn(dummyUserName);
+
+        mockResponse = mock(HttpServletResponse.class);
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantIdOfUser(dummyUserName)).thenReturn(-1234);
+
+        mockStatic(User.class);
+        mockUser = mock(User.class);
+        when(User.getUserFromUserName(anyString())).thenReturn(mockUser);
+
+        mockStatic(CustomBasicAuthenticatorServiceComponent.class);
+        mockRealmService = mock(RealmService.class);
+        when(CustomBasicAuthenticatorServiceComponent.getRealmService()).thenReturn(mockRealmService);
+        mockRealm = mock(UserRealm.class);
+        mockUserStoreManager = mock(UserStoreManager.class);
+        when(CustomBasicAuthenticatorServiceComponent.getRealmService().getTenantUserRealm(-1234)).thenThrow(new org
+                .wso2.carbon.user.api.UserStoreException());
+        try {
+            customBasicAuthenticator.processAuthenticationResponse(
+                    mockRequest, mockResponse, mockAuthnCtxt);
+        } catch (AuthenticationFailedException e) {
+            assertNotNull(e);
+        }
+    }
+
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+}
+

--- a/custom-basic-authenticator-for-username-only-authentication/src/test/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/internal/CustomBasicAuthenticatorServiceComponentTestCase.java
+++ b/custom-basic-authenticator-for-username-only-authentication/src/test/java/org/wso2/carbon/identity/application/authenticator/custombasicauth/internal/CustomBasicAuthenticatorServiceComponentTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.custombasicauth.internal;
+
+import org.osgi.service.component.ComponentContext;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.testutil.IdentityBaseTest;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.testng.Assert.assertNotNull;
+
+public class CustomBasicAuthenticatorServiceComponentTestCase extends IdentityBaseTest {
+
+    private RealmService mockRealmService;
+    private CustomBasicAuthenticatorServiceComponent customBasicAuthenticatorServiceComponent;
+    private ComponentContext mockComponentContext;
+
+    @BeforeTest
+    public void setup() {
+
+        customBasicAuthenticatorServiceComponent = new CustomBasicAuthenticatorServiceComponent();
+    }
+
+    @Test
+    public void setRealmTestCase() throws NoSuchFieldException, IllegalAccessException {
+        mockRealmService = mock(RealmService.class);
+        customBasicAuthenticatorServiceComponent.setRealmService(mockRealmService);
+        assertNotNull(CustomBasicAuthenticatorServiceComponent.getRealmService());
+    }
+
+    @Test
+    public void deactivateTestCase() throws NoSuchFieldException, IllegalAccessException {
+        mockComponentContext = mock(ComponentContext.class);
+        customBasicAuthenticatorServiceComponent.deactivate(mockComponentContext);
+    }
+
+    @Test
+    public void unSetRealmTestCase() throws NoSuchFieldException, IllegalAccessException {
+        mockRealmService = mock(RealmService.class);
+        customBasicAuthenticatorServiceComponent.unsetRealmService(mockRealmService);
+    }
+}

--- a/custom-basic-authenticator-for-username-only-authentication/src/test/resources/testng.xml
+++ b/custom-basic-authenticator-for-username-only-authentication/src/test/resources/testng.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="custom-basicauth-test-suite">
+
+    <test name="custombasic-authenticator-tests-with-debug-logs" preserve-order="true" parallel="false">
+        <parameter name="log-level" value="debug"/>
+        <classes>
+            <class name="org.wso2.carbon.identity.application.authenticator.custombasicauth.CustomBasicAuthenticatorTestCase"/>
+            <class name="org.wso2.carbon.identity.application.authenticator.custombasicauth.internal.CustomBasicAuthenticatorServiceComponentTestCase"/>
+        </classes>
+    </test>
+
+    <test name="custombasic-authenticator-tests-with-info-logs" preserve-order="true" parallel="false">
+        <parameter name="log-level" value="info"/>
+        <classes>
+            <class name="org.wso2.carbon.identity.application.authenticator.custombasicauth.CustomBasicAuthenticatorTestCase"/>
+            <class name="org.wso2.carbon.identity.application.authenticator.custombasicauth.internal.CustomBasicAuthenticatorServiceComponentTestCase"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose
Enabling the user to authenticate only with the user name for trusted users and SMS OTP as the second factor for verification.

## Goals
This custom basic authenticator modifies the default basic authenticator to prevent being prompted for the password. Instead authenticates the user if exists in the user store. 

## Approach 
N/A

## User stories
N/A

## Release note
Since we are validating the user name in the identifier-first step, there is security risk of an attacker getting information about the user's stored in the system by brute-forcing user names. This is a consideration between security and usability. 

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
This feature is tested with the IS 5.7.0.
 
## Learning
https://docs.wso2.com/display/IS570/Configuring+SMS+OTP